### PR TITLE
도감 내 파트너 포켓몬 표시 기능 구현

### DIFF
--- a/src/components/pokemon/PokemonCardItem.jsx
+++ b/src/components/pokemon/PokemonCardItem.jsx
@@ -1,14 +1,10 @@
-// components/pokemon/PokemonCardItem.jsx
-import React from "react";
 import styled from "styled-components";
 
 const PokemonCardItem = ({ pokemon, isSelected, onClick }) => {
   return (
     // $을 통해 스타일 전용 Props로 만들어 DOM에는 전달 안되도록 설정
     <PokemonCard key={pokemon.id} onClick={onClick} $owned={pokemon.owned}>
-      {pokemon.isPartner && (
-        <PartnerIcon src="img/partner.png" alt="파트너 포켓몬" />
-      )}
+      {pokemon.isPartner && <PartnerIcon src="img/partner.png" alt="파트너 포켓몬" />}
       {isSelected && (
         <>
           <div className="corner top-left selected" />
@@ -17,11 +13,7 @@ const PokemonCardItem = ({ pokemon, isSelected, onClick }) => {
           <div className="corner bottom-right selected" />
         </>
       )}
-      <PokeCardImg
-        src={pokemon.url}
-        alt={pokemon.name}
-        $owned={pokemon.owned}
-      />
+      <PokeCardImg src={pokemon.url} alt={pokemon.name} $owned={pokemon.owned} />
     </PokemonCard>
   );
 };
@@ -137,8 +129,8 @@ const PokeCardImg = styled.img`
 
 const PartnerIcon = styled.img`
   position: absolute;
-  top: 8px;
-  left: 8px;
+  bottom: 4px;
+  right: 4px;
   width: 24px;
   height: 24px;
   z-index: 2;

--- a/src/pages/PokeDevPage.jsx
+++ b/src/pages/PokeDevPage.jsx
@@ -5,8 +5,9 @@ import styled from "styled-components";
 import { toast } from "react-toastify";
 import { fetchMyPokemons } from "../apis/PokeApi";
 import PokemonCardItem from "../components/pokemon/PokemonCardItem";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { setPartnerPokemon } from "../store/thunks/user";
+import { selectMyPartnerPokemon } from "../store/slices/user";
 
 const myPokemonListDemo = [
   {
@@ -82,6 +83,8 @@ const typeColors = {
 
 const PokeDevPage = () => {
   const dispatch = useDispatch();
+
+  const partnerPokemon = useSelector(selectMyPartnerPokemon);
   // 현재 선택된 포켓몬
   const [selectedPokemon, setSelectedPokemon] = useState(null);
 
@@ -93,7 +96,9 @@ const PokeDevPage = () => {
     const loadPokemons = async () => {
       try {
         const data = await fetchMyPokemons();
-        setMyPokemonList(data);
+        setMyPokemonList(
+          data.map((pokemon) => ({ ...pokemon, isPartner: pokemon.id === partnerPokemon?.id }))
+        );
         console.log("내 포켓몬 목록:", data);
       } catch (error) {
         setMyPokemonList(myPokemonListDemo); // 임시 데이터로 대체
@@ -102,7 +107,7 @@ const PokeDevPage = () => {
     };
 
     loadPokemons();
-  }, []);
+  }, [partnerPokemon]);
 
   // 파트너 포켓몬 등록
   const handleSetPartner = () => {

--- a/src/store/slices/user.js
+++ b/src/store/slices/user.js
@@ -73,6 +73,10 @@ const userSlice = createSlice({
 export const selectMyInfo = (state) => state.user?.me;
 export const selectMyRoutines = (state) => state.user?.myRoutines;
 export const selectIsLoggedIn = (state) => (state.user?.me ? true : false);
+export const selectMyPartnerPokemon = (state) =>
+  state.user?.me?.pokemonId
+    ? { id: state.user?.me.pokemonId, name: state.user?.me.pokemonName, url: state.user?.me.url }
+    : null;
 
 const { actions, reducer } = userSlice;
 


### PR DESCRIPTION
도감 페이지 내 파트너 포켓몬을 표시하는 기능 구현.

기존에 isPartner 값에 따라 파트너 포켓몬 아이콘을 보여주는 코드는 있어서, 포켓몬 도감 데이터에 isPartner 속성을 추가하는 코드를 작성하였습니다.
리덕스의 내 정보에 파트너 포켓몬에 대한 정보가 이미 존재하기에 useSelector hook을 사용해 해당 정보를 불러오고, fetch한 포켓몬 데이터를 map함수로 가공하여 isPartner 속성을 추가하였습니다.

또한 파트너 포켓몬 아이콘의 위치를 일부 수정하였습니다.